### PR TITLE
Add watch endpoint

### DIFF
--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -9,4 +9,4 @@ export * from './genre';
 export * from './movies';
 export * from './configuration';
 export * from './tv-shows';
-export * from './watch';
+export * from './watch-providers';

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -9,3 +9,4 @@ export * from './genre';
 export * from './movies';
 export * from './configuration';
 export * from './tv-shows';
+export * from './watch';

--- a/src/endpoints/watch-providers.ts
+++ b/src/endpoints/watch-providers.ts
@@ -11,23 +11,23 @@ export interface WatchProviderResponse {
   results: Array<WatchProvider>
 }
 
-export class WatchEndpoint extends BaseEndpoint {
+export class WatchProvidersEndpoint extends BaseEndpoint {
   constructor(protected readonly accessToken: string) {
     super(accessToken);
   }
 
-  async getRegions(language?: string): Promise<RegionResponse> {
-    const params = querystring.encode({ language: language });
+  async getRegions(language_iso_639_1?: string): Promise<RegionResponse> {
+    const params = querystring.encode({ language: language_iso_639_1 });
     return await this.api.get<RegionResponse>(`/watch/providers/regions?${params}`);
   }
 
-  async getMovieWatchProviders(language?: string, region?: string): Promise<WatchProviderResponse> {
-    const params = querystring.encode({ language: language, watch_region: region  });
+  async getMovieProviders(language_iso_639_1?: string, region_iso_3166_1?: string): Promise<WatchProviderResponse> {
+    const params = querystring.encode({ language: language_iso_639_1, watch_region: region_iso_3166_1 });
     return await this.api.get<WatchProviderResponse>(`/watch/providers/movie?${params}`);
   }
 
-  async getTvWatchProviders(language?: string, region?: string): Promise<WatchProviderResponse> {
-    const params = querystring.encode({ language: language, watch_region: region  });
+  async getTvProviders(language_iso_639_1?: string, region_iso_3166_1?: string): Promise<WatchProviderResponse> {
+    const params = querystring.encode({ language: language_iso_639_1, watch_region: region_iso_3166_1  });
     return await this.api.get<WatchProviderResponse>(`/watch/providers/tv?${params}`);
   }
 }

--- a/src/endpoints/watch.ts
+++ b/src/endpoints/watch.ts
@@ -1,0 +1,33 @@
+import { BaseEndpoint } from './base';
+import querystring from 'querystring';
+import { Region } from '../types/regions';
+import { WatchProvider } from '../types';
+
+export interface RegionResponse {
+  results: Array<Region>
+}
+
+export interface WatchProviderResponse {
+  results: Array<WatchProvider>
+}
+
+export class WatchEndpoint extends BaseEndpoint {
+  constructor(protected readonly accessToken: string) {
+    super(accessToken);
+  }
+
+  async getRegions(language?: string): Promise<RegionResponse> {
+    const params = querystring.encode({ language: language });
+    return await this.api.get<RegionResponse>(`/watch/providers/regions?${params}`);
+  }
+
+  async getMovieWatchProviders(language?: string, region?: string): Promise<WatchProviderResponse> {
+    const params = querystring.encode({ language: language, watch_region: region  });
+    return await this.api.get<WatchProviderResponse>(`/watch/providers/movie?${params}`);
+  }
+
+  async getTvWatchProviders(language?: string, region?: string): Promise<WatchProviderResponse> {
+    const params = querystring.encode({ language: language, watch_region: region  });
+    return await this.api.get<WatchProviderResponse>(`/watch/providers/tv?${params}`);
+  }
+}

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -8,7 +8,7 @@ import {
   SearchEndpoint,
   TvShowsEndpoint,
   ConfigurationEndpoint,
-  WatchEndpoint,
+  WatchProvidersEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -54,7 +54,7 @@ export default class TMDB {
     return new TvShowsEndpoint(this.accessToken);
   }
 
-  get watch(): WatchEndpoint{
-    return new WatchEndpoint(this.accessToken);
+  get watchProviders(): WatchProvidersEndpoint{
+    return new WatchProvidersEndpoint(this.accessToken);
   }
 }

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -8,6 +8,7 @@ import {
   SearchEndpoint,
   TvShowsEndpoint,
   ConfigurationEndpoint,
+  WatchEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -51,5 +52,9 @@ export default class TMDB {
 
   get tvShows(): TvShowsEndpoint{
     return new TvShowsEndpoint(this.accessToken);
+  }
+
+  get watch(): WatchEndpoint{
+    return new WatchEndpoint(this.accessToken);
   }
 }

--- a/src/types/regions.ts
+++ b/src/types/regions.ts
@@ -1,0 +1,5 @@
+export interface Region {
+  iso_3166_1: string,
+  english_name: string,
+  native_name: string
+}

--- a/src/types/watch-providers.ts
+++ b/src/types/watch-providers.ts
@@ -1,3 +1,10 @@
+export interface WatchProvider {
+  display_priorities: any;
+  display_priority: number;
+  logo_path: string;
+  provider_id: number;
+  provider_name: string;
+}
 
 export interface Flatrate {
   display_priority: number;


### PR DESCRIPTION
# Watch Providers endpoint!
I added support for the [watch providers endpoints](https://www.themoviedb.org/settings/api). The endpoints return the full list of supported region codes & the full list of watch providers.

## Additions
* New types: Region and WatchProvider
* Watch Providers endpoint added to the TMDB class
  * Includes 3 GET endpoints: regions, tv providers, and movie providers

## Benefit
Lets you store the watch providers in your own database

## Test it out
```
const tmdb = new TMDB(<api key>);

// List the names of all the movie providers in the US
tmdb.watchProviders.getMovieProviders().then(response => {
  response.results.forEach(provider => {
    console.log(provider.provider_name);
  });
});

// Get regions in english
tmdb.watchProviders.getRegions().then(console.log);

// Get regions in german
tmdb.watchProviders.getRegions('de').then(console.log);
```
