### PR TITLE
Add people endpoint

### DIFF
--- a/src/endpoints/changes.ts
+++ b/src/endpoints/changes.ts
@@ -1,6 +1,7 @@
 import querystring  from 'querystring';
 import { BaseEndpoint } from './base';
-import { ChangeOptions, Changes } from '../types/changes';
+import { Change, ChangeOptions } from '../types/changes';
+import { PaginatedResult } from '../types';
 
 
 export class ChangeEndpoint extends BaseEndpoint {
@@ -8,19 +9,19 @@ export class ChangeEndpoint extends BaseEndpoint {
     super(accessToken);
   }
 
-  async movies(options?: ChangeOptions): Promise<Changes> {
+  async movies(options?: ChangeOptions): Promise<PaginatedResult<Change>> {
     const params = querystring.encode(options);
-    return await this.api.get<Changes>(`/movie/changes?${params}`);
+    return await this.api.get<PaginatedResult<Change>>(`/movie/changes?${params}`);
   }
 
-  async tvShows(options?: ChangeOptions): Promise<Changes> {
+  async tvShows(options?: ChangeOptions): Promise<PaginatedResult<Change>> {
     const params = querystring.stringify(options);
-    return await this.api.get<Changes>(`/tv/changes?${params}`);
+    return await this.api.get<PaginatedResult<Change>>(`/tv/changes?${params}`);
   }
 
-  async person(options?: ChangeOptions): Promise<Changes> {
+  async person(options?: ChangeOptions): Promise<PaginatedResult<Change>> {
     const params = querystring.stringify(options);
 
-    return await this.api.get<Changes>(`/person/changes${params}`);
+    return await this.api.get<PaginatedResult<Change>>(`/person/changes${params}`);
   }
 }

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -9,3 +9,5 @@ export * from './genre';
 export * from './movies';
 export * from './configuration';
 export * from './tv-shows';
+export * from './people';
+

--- a/src/endpoints/movies.ts
+++ b/src/endpoints/movies.ts
@@ -7,17 +7,17 @@ import {
   Images,
   Keywords,
   LatestMovie,
+  Movie,
   MovieChanges,
   MovieDetails,
-  MovieLists,
+  MovieList,
   MoviesPlayingNow,
-  PopularMovies,
-  Recommendations,
+  PaginatedResult,
+  Recommendation,
   ReleaseDates,
   Reviews,
-  SimilarMovies,
-  TopRatedMovies, TranslationData, Translations,
-  UpcomingMovies,
+  TranslationData,
+  Translations,
   Videos,
   WatchProviders,
 } from '../types';
@@ -59,14 +59,14 @@ export class MoviesEndpoint extends BaseEndpoint{
     return await this.api.get<Keywords>(`${BASE_MOVIE}/${id}/keywords`);
   }
 
-  async lists(id: number, options?: {page?: number}): Promise<MovieLists>{
+  async lists(id: number, options?: {page?: number}): Promise<PaginatedResult<MovieList>>{
     const params = querystring.encode(options);
-    return await this.api.get<MovieLists>(`${BASE_MOVIE}/${id}/lists?${params}`);
+    return await this.api.get<PaginatedResult<MovieList>>(`${BASE_MOVIE}/${id}/lists?${params}`);
   }
 
-  async recommendations(id: number, options?: {page?: number}): Promise<Recommendations>{
+  async recommendations(id: number, options?: {page?: number}): Promise<PaginatedResult<Recommendation>>{
     const params = querystring.encode(options);
-    return await this.api.get<Recommendations>(`${BASE_MOVIE}/${id}/recommendations?${params}`);
+    return await this.api.get<PaginatedResult<Recommendation>>(`${BASE_MOVIE}/${id}/recommendations?${params}`);
   }
 
   async releaseDates(id: number): Promise<ReleaseDates>{
@@ -78,9 +78,9 @@ export class MoviesEndpoint extends BaseEndpoint{
     return await this.api.get<Reviews>(`${BASE_MOVIE}/${id}/reviews?${params}`);
   }
 
-  async similar(id: number, options?: {page?: number}): Promise<SimilarMovies>{
+  async similar(id: number, options?: {page?: number}): Promise<PaginatedResult<Movie>>{
     const params = querystring.encode(options);
-    return await this.api.get<SimilarMovies>(`${BASE_MOVIE}/${id}/similar?${params}`);
+    return await this.api.get<PaginatedResult<Movie>>(`${BASE_MOVIE}/${id}/similar?${params}`);
   }
 
   async translations(id: number): Promise<Translations<TranslationData>>{
@@ -108,19 +108,19 @@ export class MoviesEndpoint extends BaseEndpoint{
     return await this.api.get<MoviesPlayingNow>(`${BASE_MOVIE}/now_playing?${params}`);
   }
 
-  async popular(options?: {page?: number}): Promise<PopularMovies>{
+  async popular(options?: {page?: number}): Promise<PaginatedResult<Movie>>{
     const params = querystring.encode(options);
-    return await this.api.get<PopularMovies>(`${BASE_MOVIE}/popular?${params}`);
+    return await this.api.get<PaginatedResult<Movie>>(`${BASE_MOVIE}/popular?${params}`);
   }
 
-  async topRated(options?: {page?: number, region?: string, language?: string}): Promise<TopRatedMovies>{
+  async topRated(options?: {page?: number, region?: string, language?: string}): Promise<PaginatedResult<Movie>>{
     const params = querystring.encode(options);
-    return await this.api.get<TopRatedMovies>(`${BASE_MOVIE}/top_rated?${params}`);
+    return await this.api.get<PaginatedResult<Movie>>(`${BASE_MOVIE}/top_rated?${params}`);
   }
 
-  async upcoming(options?: {page?: number, region?: string, language?: string}): Promise<UpcomingMovies>{
+  async upcoming(options?: {page?: number, region?: string, language?: string}): Promise<PaginatedResult<Movie>>{
     const params = querystring.encode(options);
-    return await this.api.get<UpcomingMovies>(`${BASE_MOVIE}/upcoming?${params}`);
+    return await this.api.get<PaginatedResult<Movie>>(`${BASE_MOVIE}/upcoming?${params}`);
   }
 }
 

--- a/src/endpoints/movies.ts
+++ b/src/endpoints/movies.ts
@@ -16,7 +16,7 @@ import {
   ReleaseDates,
   Reviews,
   SimilarMovies,
-  TopRatedMovies, Translations,
+  TopRatedMovies, TranslationData, Translations,
   UpcomingMovies,
   Videos,
   WatchProviders,
@@ -83,8 +83,8 @@ export class MoviesEndpoint extends BaseEndpoint{
     return await this.api.get<SimilarMovies>(`${BASE_MOVIE}/${id}/similar?${params}`);
   }
 
-  async translations(id: number): Promise<Translations>{
-    return await this.api.get<Translations>(`${BASE_MOVIE}/${id}/translations`);
+  async translations(id: number): Promise<Translations<TranslationData>>{
+    return await this.api.get<Translations<TranslationData>>(`${BASE_MOVIE}/${id}/translations`);
   }
 
   async videos(id: number): Promise<Videos>{

--- a/src/endpoints/people.ts
+++ b/src/endpoints/people.ts
@@ -1,4 +1,4 @@
-import { PersonDetail, PersonMovieCredit, PersonTvShowCredit } from '../types';
+import { CreditImages, ExternalIds, Image, PersonCombinedCredits, PersonDetail, PersonMovieCredit, PersonTvShowCredit, Translation } from '../types';
 import { BaseEndpoint } from './base';
 
 const BASE_PERSON = '/person';
@@ -29,4 +29,21 @@ export class PeopleEndpoint extends BaseEndpoint {
 			`${BASE_PERSON}/${id}/tv_credits`
 		);
 	}
+
+	async combinedCredits(id: number) : Promise<PersonCombinedCredits>{
+		return await this.api.get<PersonCombinedCredits>(`${BASE_PERSON}/${id}/combined_credits`)
+	}
+
+	async externalId(id: number): Promise<ExternalIds>{
+		return await this.api.get<ExternalIds>(`${BASE_PERSON}/${id}/external_ids`)
+	}
+
+	async images(id: number): Promise<{id: number, profiles: Image[]}>{
+		return await this.api.get<{id: number, profiles: Image[]}>(`${BASE_PERSON}/${id}/images`)
+	}
+
+	async translation(id: number) : Promise<Translation<{biography: string}>>{
+		return await this.api.get<Translation<{biography: string}>>(`${BASE_PERSON}/${id}/translations`)
+	}
+
 }

--- a/src/endpoints/people.ts
+++ b/src/endpoints/people.ts
@@ -1,0 +1,32 @@
+import { PersonDetail, PersonMovieCredit, PersonTvShowCredit } from '../types';
+import { BaseEndpoint } from './base';
+
+const BASE_PERSON = '/person';
+
+
+
+export class PeopleEndpoint extends BaseEndpoint {
+	constructor(accessToken: string) {
+		super(accessToken);
+	}
+
+	async details(id: number): Promise<PersonDetail> {
+		return await this.api.get<PersonDetail>(`${BASE_PERSON}/${id}`);
+	}
+
+	async movieCredits(
+		id: number
+	): Promise<PersonMovieCredit> {
+		return await this.api.get<PersonMovieCredit>(
+			`${BASE_PERSON}/${id}/movie_credits`
+		);
+	}
+
+	async tvShowCredits(
+		id: number
+	): Promise<PersonTvShowCredit> {
+		return await this.api.get<PersonTvShowCredit>(
+			`${BASE_PERSON}/${id}/tv_credits`
+		);
+	}
+}

--- a/src/endpoints/people.ts
+++ b/src/endpoints/people.ts
@@ -1,5 +1,6 @@
-import { CreditImages, ExternalIds, Image, PersonCombinedCredits, PersonDetail, PersonMovieCredit, PersonTvShowCredit, Translation } from '../types';
+import { ChangeOptions, ExternalIds, IdPaginatedResult, Image, PaginatedResult, Person, PersonChanges, PersonCombinedCredits, PersonDetail, PersonMovieCredit, PersonTvShowCredit, TaggedImage, Translations } from '../types';
 import { BaseEndpoint } from './base';
+import querystring from 'querystring';
 
 const BASE_PERSON = '/person';
 
@@ -12,6 +13,11 @@ export class PeopleEndpoint extends BaseEndpoint {
 
 	async details(id: number): Promise<PersonDetail> {
 		return await this.api.get<PersonDetail>(`${BASE_PERSON}/${id}`);
+	}
+
+	async changes(id: number, options? : ChangeOptions): Promise<PersonChanges> {
+		const params = querystring.encode(options);
+		return await this.api.get<PersonChanges>(`${BASE_PERSON}/${id}/changes?${params}`);
 	}
 
 	async movieCredits(
@@ -42,8 +48,22 @@ export class PeopleEndpoint extends BaseEndpoint {
 		return await this.api.get<{id: number, profiles: Image[]}>(`${BASE_PERSON}/${id}/images`)
 	}
 
-	async translation(id: number) : Promise<Translation<{biography: string}>>{
-		return await this.api.get<Translation<{biography: string}>>(`${BASE_PERSON}/${id}/translations`)
+	async taggedImages(id: number, options?: {page?: number}): Promise<IdPaginatedResult<TaggedImage>>{
+		const params = querystring.encode(options);
+		return await this.api.get<IdPaginatedResult<TaggedImage>>(`${BASE_PERSON}/${id}/tagged_images?${options}`);
+	}
+
+	async translation(id: number) : Promise<Translations<{biography: string}>>{
+		return await this.api.get<Translations<{biography: string}>>(`${BASE_PERSON}/${id}/translations`)
+	}
+
+	async latest(): Promise<PersonDetail>{
+		return await this.api.get<PersonDetail>(`${BASE_PERSON}/latest`);
+	}
+
+	async popular(options?: {page?: number}): Promise<PaginatedResult<Person>>{
+		const params = querystring.encode(options);
+		return await this.api.get<PaginatedResult<Person>>(`${BASE_PERSON}/popular?${params}`);
 	}
 
 }

--- a/src/endpoints/tv-shows.ts
+++ b/src/endpoints/tv-shows.ts
@@ -1,5 +1,6 @@
 import { BaseEndpoint } from './base';
 import {
+  AiringTodayResult,
   AlternativeTitles,
   ChangeOptions,
   ContentRatings,
@@ -9,19 +10,19 @@ import {
   Images,
   Keywords,
   LatestTvShows,
-  OnTheAir,
-  PopularTvShows,
-  Recommendations,
+  OnTheAirResult,
+  PaginatedResult,
+  PopularTvShowResult,
+  Recommendation,
   Reviews,
   ScreenedTheatrically,
   SeasonDetails,
-  SimilarTvShows,
-  TopRatedTvShows,
+  SimilarTvShow,
+  TopRatedTvShowResult,
   TranslationData,
   Translations,
   TvShowChanges,
   TvShowDetails,
-  TvShowsAiringToday,
   Videos,
   WatchProviders,
 } from '../types';
@@ -75,9 +76,9 @@ export class TvShowsEndpoint extends BaseEndpoint{
     return await this.api.get<Keywords>(`${BASE_TV}/${id}/keywords`);
   }
 
-  async recommendations(id: number, options?: {page?: number}): Promise<Recommendations>{
+  async recommendations(id: number, options?: {page?: number}): Promise<PaginatedResult<Recommendation>>{
     const params = querystring.encode(options);
-    return await this.api.get<Recommendations>(`${BASE_TV}/${id}/recommendations?${params}`);
+    return await this.api.get<PaginatedResult<Recommendation>>(`${BASE_TV}/${id}/recommendations?${params}`);
   }
 
   async reviews(id: number, options?: {page?: number}): Promise<Reviews>{
@@ -89,9 +90,9 @@ export class TvShowsEndpoint extends BaseEndpoint{
     return await this.api.get<ScreenedTheatrically>(`${BASE_TV}/${id}/screened_theatrically`);
   }
 
-  async similar(id: number, options?: {page?: number}): Promise<SimilarTvShows>{
+  async similar(id: number, options?: {page?: number}): Promise<PaginatedResult<SimilarTvShow>>{
     const params = querystring.encode(options);
-    return await this.api.get<SimilarTvShows>(`${BASE_TV}/${id}/similar?${params}`);
+    return await this.api.get<PaginatedResult<SimilarTvShow>>(`${BASE_TV}/${id}/similar?${params}`);
   }
 
   async translations(id: number): Promise<Translations<TranslationData>>{
@@ -114,23 +115,23 @@ export class TvShowsEndpoint extends BaseEndpoint{
     return await this.api.get<LatestTvShows>(`${BASE_TV}/latest`);
   }
 
-  async onTheAir(): Promise<OnTheAir>{
-    return await this.api.get<OnTheAir>(`${BASE_TV}/on_the_air`);
+  async onTheAir(): Promise<PaginatedResult<OnTheAirResult>>{
+    return await this.api.get<PaginatedResult<OnTheAirResult>>(`${BASE_TV}/on_the_air`);
   }
 
-  async airingToday(options?: {page?: number, region?: string, language?: string}): Promise<TvShowsAiringToday>{
+  async airingToday(options?: {page?: number, region?: string, language?: string}): Promise<PaginatedResult<AiringTodayResult>>{
     const params = querystring.encode(options);
-    return await this.api.get<TvShowsAiringToday>(`${BASE_TV}/airing_today?${params}`);
+    return await this.api.get<PaginatedResult<AiringTodayResult>>(`${BASE_TV}/airing_today?${params}`);
   }
 
-  async popular(options?: {page?: number}): Promise<PopularTvShows>{
+  async popular(options?: {page?: number}): Promise<PaginatedResult<PopularTvShowResult>>{
     const params = querystring.encode(options);
-    return await this.api.get<PopularTvShows>(`${BASE_TV}/popular?${params}`);
+    return await this.api.get<PaginatedResult<PopularTvShowResult>>(`${BASE_TV}/popular?${params}`);
   }
 
-  async topRated(options?: {page?: number, region?: string, language?: string}): Promise<TopRatedTvShows>{
+  async topRated(options?: {page?: number, region?: string, language?: string}): Promise<PaginatedResult<TopRatedTvShowResult>>{
     const params = querystring.encode(options);
-    return await this.api.get<TopRatedTvShows>(`${BASE_TV}/top_rated?${params}`);
+    return await this.api.get<PaginatedResult<TopRatedTvShowResult>>(`${BASE_TV}/top_rated?${params}`);
   }
 
 }

--- a/src/endpoints/tv-shows.ts
+++ b/src/endpoints/tv-shows.ts
@@ -17,6 +17,7 @@ import {
   SeasonDetails,
   SimilarTvShows,
   TopRatedTvShows,
+  TranslationData,
   Translations,
   TvShowChanges,
   TvShowDetails,
@@ -93,8 +94,8 @@ export class TvShowsEndpoint extends BaseEndpoint{
     return await this.api.get<SimilarTvShows>(`${BASE_TV}/${id}/similar?${params}`);
   }
 
-  async translations(id: number): Promise<Translations>{
-    return await this.api.get<Translations>(`${BASE_TV}/${id}/translations`);
+  async translations(id: number): Promise<Translations<TranslationData>>{
+    return await this.api.get<Translations<TranslationData>>(`${BASE_TV}/${id}/translations`);
   }
 
   async videos(id: number): Promise<Videos>{

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -8,6 +8,7 @@ import {
   SearchEndpoint,
   TvShowsEndpoint,
   ConfigurationEndpoint,
+  PeopleEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -51,5 +52,9 @@ export default class TMDB {
 
   get tvShows(): TvShowsEndpoint{
     return new TvShowsEndpoint(this.accessToken);
+  }
+
+  get people(): PeopleEndpoint{
+    return new PeopleEndpoint(this.accessToken);
   }
 }

--- a/src/types/changes.ts
+++ b/src/types/changes.ts
@@ -5,13 +5,6 @@ export interface Change {
   adult: boolean | undefined;
 }
 
-export interface Changes{
-  results: Change[];
-  page: number;
-  total_pages: number;
-  total_results: number;
-}
-
 export interface ChangeOptions extends ParsedUrlQueryInput {
   end_date?: string;
   start_date?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,10 +152,9 @@ export interface Recommendation {
   vote_count: number;
 }
 
-
-export interface Recommendations {
+export interface PaginatedResult<T>{
   page: number;
-  results: Recommendation[];
+  results: T[];
   total_pages: number;
   total_results: number;
 }
@@ -170,12 +169,8 @@ export interface Review {
   url: string;
 }
 
-export interface Reviews {
+export interface Reviews extends PaginatedResult<Review> {
   id: number;
-  page: number;
-  results: Review[];
-  total_pages: number;
-  total_results: number;
 }
 
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -159,6 +159,10 @@ export interface PaginatedResult<T>{
   total_results: number;
 }
 
+export interface IdPaginatedResult<T> extends PaginatedResult<T>{
+  id: number;
+}
+
 export interface Review {
   author: string;
   author_details: AuthorDetails;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './movies';
 export * from './search';
 export * from './tv-shows';
 export * from './watch-providers';
+export * from './people';
 
 export interface AuthorDetails {
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -185,15 +185,25 @@ export interface TranslationData {
   homepage: string;
 }
 
-export interface Translation {
+export interface Translation<T> {
   iso_3166_1: string;
   iso_639_1: string;
   name: string;
   english_name: string;
-  data: TranslationData;
+  data: T;
 }
 
-export interface Translations {
+export interface Translations<T> {
   id: number;
-  translations: Translation[];
+  translations: Translation<T>[];
+}
+
+export interface Image{
+aspect_ratio: number;
+file_path: string;
+height: number;
+iso_639_1: string;
+vote_average: number;
+vote_count: number;
+width: number;
 }

--- a/src/types/movies.ts
+++ b/src/types/movies.ts
@@ -1,4 +1,4 @@
-import { Genre, Movie, ProductionCompany, ProductionCountry, SpokenLanguage } from './';
+import { Genre, Movie, PaginatedResult, ProductionCompany, ProductionCountry, SpokenLanguage } from './';
 
 export interface MovieDetails {
   adult: boolean;
@@ -55,14 +55,6 @@ export interface ReleaseDates {
   results: ReleaseDateResult[];
 }
 
-
-export interface SimilarMovies {
-  page: number;
-  results: Movie[];
-  total_pages: number;
-  total_results: number;
-}
-
 export interface MovieList {
   description: string;
   favorite_count: number;
@@ -73,15 +65,6 @@ export interface MovieList {
   name: string;
   poster_path: string;
 }
-
-export interface MovieLists {
-  id: number;
-  page: number;
-  results: MovieList[];
-  total_pages: number;
-  total_results: number;
-}
-
 
 export interface MovieChangeItem {
   id: string;
@@ -135,31 +118,6 @@ export interface Dates {
   minimum: string;
 }
 
-export interface MoviesPlayingNow {
-  page: number;
-  results: Movie[];
+export interface MoviesPlayingNow extends PaginatedResult<Movie> {
   dates: Dates;
-  total_pages: number;
-  total_results: number;
-}
-
-export interface PopularMovies {
-  page: number;
-  results: Movie[];
-  total_results: number;
-  total_pages: number;
-}
-
-export interface TopRatedMovies {
-  page: number;
-  results: Movie[];
-  total_results: number;
-  total_pages: number;
-}
-
-export interface UpcomingMovies {
-  page: number;
-  results: Movie[];
-  total_results: number;
-  total_pages: number;
 }

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -71,6 +71,12 @@ export interface PersonTvShowCredit {
 	id: number;
 }
 
+export interface PersonCombinedCredits{
+	cast: (PersonMovieCast & PersonTvShowCast)[];
+	crew: (PersonMovieCrew & PersonTvShowCrew)[];
+	id: number;
+}
+
 export interface PersonDetail {
 	birthday: string,
 	known_for_department: string,

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -1,3 +1,5 @@
+import { Image, Movie, TV } from ".";
+
 interface Cast {
 	character: string;
 	credit_id: string;
@@ -71,7 +73,7 @@ export interface PersonTvShowCredit {
 	id: number;
 }
 
-export interface PersonCombinedCredits{
+export interface PersonCombinedCredits {
 	cast: (PersonMovieCast & PersonTvShowCast)[];
 	crew: (PersonMovieCrew & PersonTvShowCrew)[];
 	id: number;

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -1,0 +1,89 @@
+interface Cast {
+	character: string;
+	credit_id: string;
+	vote_count: number;
+	id: number;
+	backdrop_path: string;
+	poster_path: string;
+	original_language: string;
+	vote_average: number;
+	genre_ids: number[];
+	popularity: number;
+	overview: string;
+}
+
+interface Crew {
+	id: number;
+	department: string;
+	original_language: string;
+	credit_id: string;
+	overview: string;
+	vote_count: number;
+	poster_path: string;
+	backdrop_path: string;
+	popularity: number;
+	genre_ids: number[];
+	job: string;
+	vote_average: number;
+}
+
+export interface PersonMovieCast extends Cast {
+	release_date: string;
+	video: boolean;
+	adult: boolean;
+	title: string;
+	original_title: string;
+}
+
+export interface PersonMovieCrew extends Crew {
+	original_title: string;
+	video: boolean;
+	title: string;
+	adult: boolean;
+	release_date: string;
+}
+
+export interface PersonTvShowCrew extends Crew {
+	episode_count: number;
+	origin_country: string[];
+	original_name: string;
+	name: string;
+	first_air_date: string;
+}
+
+export interface PersonTvShowCast extends Cast {
+	original_name: string;
+	name: string;
+	episode_count: number;
+	first_air_date: string;
+	origin_country: string[];
+}
+
+export interface PersonMovieCredit {
+	cast: PersonMovieCast[];
+	crew: PersonMovieCrew[];
+	id: number;
+}
+
+export interface PersonTvShowCredit {
+	cast: PersonTvShowCast[];
+	crew: PersonTvShowCrew[];
+	id: number;
+}
+
+export interface PersonDetail {
+	birthday: string,
+	known_for_department: string,
+	deathday: string,
+	id: number,
+	name: string,
+	also_known_as: string[]
+	gender: number,
+	biography: string,
+	popularity: number,
+	place_of_birth: string,
+	profile_path: string,
+	adult: boolean,
+	imdb_id: string,
+	homepage: string
+  }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,8 +1,3 @@
-export interface Search<T> {
-  page: number;
-  results: T[];
-  total_pages: number;
-  total_results: number;
-}
+import { PaginatedResult } from ".";
 
-
+export interface Search<T> extends PaginatedResult<T> {}

--- a/src/types/tv-shows.ts
+++ b/src/types/tv-shows.ts
@@ -180,12 +180,6 @@ export interface SimilarTvShow {
   vote_count: number;
 }
 
-export interface SimilarTvShows {
-  page: number;
-  results: SimilarTvShow[];
-  total_pages: number;
-  total_results: number;
-}
 
 export interface LatestTvShows {
   backdrop_path?: any;
@@ -233,13 +227,6 @@ export interface OnTheAirResult {
   original_name: string;
 }
 
-export interface OnTheAir {
-  page: number;
-  results: OnTheAirResult[];
-  total_results: number;
-  total_pages: number;
-}
-
 
 export interface AiringTodayResult {
   poster_path: string;
@@ -257,14 +244,6 @@ export interface AiringTodayResult {
   original_name: string;
 }
 
-export interface TvShowsAiringToday {
-  page: number;
-  results: AiringTodayResult[];
-  total_results: number;
-  total_pages: number;
-}
-
-
 export interface PopularTvShowResult {
   poster_path: string;
   popularity: number;
@@ -279,13 +258,6 @@ export interface PopularTvShowResult {
   vote_count: number;
   name: string;
   original_name: string;
-}
-
-export interface PopularTvShows {
-  page: number;
-  results: PopularTvShowResult[];
-  total_results: number;
-  total_pages: number;
 }
 
 
@@ -304,12 +276,4 @@ export interface TopRatedTvShowResult {
   name: string;
   original_name: string;
 }
-
-export interface TopRatedTvShows {
-  page: number;
-  results: TopRatedTvShowResult[];
-  total_results: number;
-  total_pages: number;
-}
-
 


### PR DESCRIPTION
# People endpoint!

I added support for the [people endpoints](https://www.themoviedb.org/settings/api). All HTTP Get requests for the people TMDB endpoint are supported.

## Additions

- New types for people

- People endpoint added to the TMDB class

- All GET endpoints with /person: details, changes, movie_credits, tv_credits, combined_credits, external_ids, images, tagged_images, translations, latest, popular