### PR TITLE
add people endpoint

### DIFF
--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -9,3 +9,5 @@ export * from './genre';
 export * from './movies';
 export * from './configuration';
 export * from './tv-shows';
+export * from './people';
+

--- a/src/endpoints/people.ts
+++ b/src/endpoints/people.ts
@@ -1,8 +1,8 @@
-import { PersonDetail, PersonMovieCredit, PersonTvShowCredit } from '../types';
+import { ChangeOptions, ExternalIds, Image, PeopleTranslations, PersonChanges, PersonCombinedCredits, PersonDetail, PersonMovieCredit, PersonTvShowCredit, PopularPersons, TaggedImages } from '../types';
 import { BaseEndpoint } from './base';
+import querystring from 'querystring';
 
 const BASE_PERSON = '/person';
-
 
 
 export class PeopleEndpoint extends BaseEndpoint {
@@ -14,19 +14,46 @@ export class PeopleEndpoint extends BaseEndpoint {
 		return await this.api.get<PersonDetail>(`${BASE_PERSON}/${id}`);
 	}
 
-	async movieCredits(
-		id: number
-	): Promise<PersonMovieCredit> {
-		return await this.api.get<PersonMovieCredit>(
-			`${BASE_PERSON}/${id}/movie_credits`
-		);
+	async changes(id: number, options? : ChangeOptions): Promise<PersonChanges> {
+		const params = querystring.encode(options);
+		return await this.api.get<PersonChanges>(`${BASE_PERSON}/${id}/changes?${params}`);
 	}
 
-	async tvShowCredits(
-		id: number
-	): Promise<PersonTvShowCredit> {
-		return await this.api.get<PersonTvShowCredit>(
-			`${BASE_PERSON}/${id}/tv_credits`
-		);
+	async movieCredits(id: number): Promise<PersonMovieCredit> {
+		return await this.api.get<PersonMovieCredit>(`${BASE_PERSON}/${id}/movie_credits`);
+	}
+
+	async tvShowCredits(id: number): Promise<PersonTvShowCredit> {
+		return await this.api.get<PersonTvShowCredit>(`${BASE_PERSON}/${id}/tv_credits`);
+	}
+
+	async combinedCredits(id: number) : Promise<PersonCombinedCredits> {
+		return await this.api.get<PersonCombinedCredits>(`${BASE_PERSON}/${id}/combined_credits`)
+	}
+
+	async externalId(id: number): Promise<ExternalIds>{
+		return await this.api.get<ExternalIds>(`${BASE_PERSON}/${id}/external_ids`)
+	}
+
+	async images(id: number): Promise<{id: number, profiles: Image[]}>{
+		return await this.api.get<{id: number, profiles: Image[]}>(`${BASE_PERSON}/${id}/images`)
+	}
+
+	async taggedImages(id: number, options?: {page?: number}): Promise<TaggedImages>{
+		const params = querystring.encode(options);
+		return await this.api.get<TaggedImages>(`${BASE_PERSON}/${id}/tagged_images?${params}`);
+	}
+
+	async translation(id: number) : Promise<PeopleTranslations>{
+		return await this.api.get<PeopleTranslations>(`${BASE_PERSON}/${id}/translations`)
+	}
+
+	async latest(): Promise<PersonDetail>{
+		return await this.api.get<PersonDetail>(`${BASE_PERSON}/latest`);
+	}
+
+	async popular(options?: {page?: number}): Promise<PopularPersons>{
+		const params = querystring.encode(options);
+		return await this.api.get<PopularPersons>(`${BASE_PERSON}/popular?${params}`);
 	}
 }

--- a/src/endpoints/people.ts
+++ b/src/endpoints/people.ts
@@ -1,0 +1,32 @@
+import { PersonDetail, PersonMovieCredit, PersonTvShowCredit } from '../types';
+import { BaseEndpoint } from './base';
+
+const BASE_PERSON = '/person';
+
+
+
+export class PeopleEndpoint extends BaseEndpoint {
+	constructor(accessToken: string) {
+		super(accessToken);
+	}
+
+	async details(id: number): Promise<PersonDetail> {
+		return await this.api.get<PersonDetail>(`${BASE_PERSON}/${id}`);
+	}
+
+	async movieCredits(
+		id: number
+	): Promise<PersonMovieCredit> {
+		return await this.api.get<PersonMovieCredit>(
+			`${BASE_PERSON}/${id}/movie_credits`
+		);
+	}
+
+	async tvShowCredits(
+		id: number
+	): Promise<PersonTvShowCredit> {
+		return await this.api.get<PersonTvShowCredit>(
+			`${BASE_PERSON}/${id}/tv_credits`
+		);
+	}
+}

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -8,6 +8,7 @@ import {
   SearchEndpoint,
   TvShowsEndpoint,
   ConfigurationEndpoint,
+  PeopleEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -51,5 +52,9 @@ export default class TMDB {
 
   get tvShows(): TvShowsEndpoint{
     return new TvShowsEndpoint(this.accessToken);
+  }
+
+  get people(): PeopleEndpoint{
+    return new PeopleEndpoint(this.accessToken);
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -197,3 +197,13 @@ export interface Translations {
   id: number;
   translations: Translation[];
 }
+
+export interface Image{
+  aspect_ratio: number;
+  file_path: string;
+  height: number;
+  iso_639_1: string;
+  vote_average: number;
+  vote_count: number;
+  width: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './movies';
 export * from './search';
 export * from './tv-shows';
 export * from './watch-providers';
+export * from './people';
 
 export interface AuthorDetails {
   name: string;

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -1,0 +1,89 @@
+interface Cast {
+	character: string;
+	credit_id: string;
+	vote_count: number;
+	id: number;
+	backdrop_path: string;
+	poster_path: string;
+	original_language: string;
+	vote_average: number;
+	genre_ids: number[];
+	popularity: number;
+	overview: string;
+}
+
+interface Crew {
+	id: number;
+	department: string;
+	original_language: string;
+	credit_id: string;
+	overview: string;
+	vote_count: number;
+	poster_path: string;
+	backdrop_path: string;
+	popularity: number;
+	genre_ids: number[];
+	job: string;
+	vote_average: number;
+}
+
+export interface PersonMovieCast extends Cast {
+	release_date: string;
+	video: boolean;
+	adult: boolean;
+	title: string;
+	original_title: string;
+}
+
+export interface PersonMovieCrew extends Crew {
+	original_title: string;
+	video: boolean;
+	title: string;
+	adult: boolean;
+	release_date: string;
+}
+
+export interface PersonTvShowCrew extends Crew {
+	episode_count: number;
+	origin_country: string[];
+	original_name: string;
+	name: string;
+	first_air_date: string;
+}
+
+export interface PersonTvShowCast extends Cast {
+	original_name: string;
+	name: string;
+	episode_count: number;
+	first_air_date: string;
+	origin_country: string[];
+}
+
+export interface PersonMovieCredit {
+	cast: PersonMovieCast[];
+	crew: PersonMovieCrew[];
+	id: number;
+}
+
+export interface PersonTvShowCredit {
+	cast: PersonTvShowCast[];
+	crew: PersonTvShowCrew[];
+	id: number;
+}
+
+export interface PersonDetail {
+	birthday: string,
+	known_for_department: string,
+	deathday: string,
+	id: number,
+	name: string,
+	also_known_as: string[]
+	gender: number,
+	biography: string,
+	popularity: number,
+	place_of_birth: string,
+	profile_path: string,
+	adult: boolean,
+	imdb_id: string,
+	homepage: string
+  }

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -1,3 +1,5 @@
+import { Movie, Person, TV, TvShowItem } from ".";
+
 interface Cast {
 	character: string;
 	credit_id: string;
@@ -71,6 +73,12 @@ export interface PersonTvShowCredit {
 	id: number;
 }
 
+export interface PersonCombinedCredits {
+	cast: (PersonMovieCast & PersonTvShowCast)[];
+	crew: (PersonMovieCrew & PersonTvShowCrew)[];
+	id: number;
+}
+
 export interface PersonDetail {
 	birthday: string,
 	known_for_department: string,
@@ -86,4 +94,62 @@ export interface PersonDetail {
 	adult: boolean,
 	imdb_id: string,
 	homepage: string
-  }
+}
+
+export interface PersonChange{
+	id: string;
+	action: string;
+	time: string;
+	iso_639_1: string;
+	iso_3166_1: string;
+	value: string | { profile: { file_path: string;} };
+	original_value: string | { profile: { file_path: string; } };
+}
+
+export interface PersonChanges {
+	changes: {
+		key: string;
+		items: PersonChange[];
+	}[];
+}
+
+export interface PopularPersons{
+	page: number;
+	results: Person[];
+	total_results: number;
+	total_pages: number;
+}
+
+export interface TaggedImage{
+  aspect_ratio: number;
+  file_path: string;
+  height: number;
+  id: string;
+  iso_639_1: string;
+  vote_average: number;
+  vote_count: number;
+  width: number;
+  image_type: string;
+  media_type: string;
+  media: Movie | TV
+}
+
+export interface TaggedImages{
+	page: number;
+	results: TaggedImage[];
+	total_results: number;
+	total_pages: number;
+}
+
+export interface PeopleTranslations{
+	id: number;
+	translations: {
+	  iso_3166_1: string;
+	  iso_639_1: string;
+	  name: string;
+	  english_name: string;
+	  data: {
+		biography: string
+	  };
+	}
+}


### PR DESCRIPTION
# People endpoint!

I added support for the [people endpoints](https://www.themoviedb.org/settings/api). All HTTP Get requests for the people TMDB endpoint are supported.

## Additions

- New types for people

- People endpoint added to the TMDB class

- All GET endpoints with /person: details, changes, movie_credits, tv_credits, combined_credits, external_ids, images, tagged_images, translations, latest, popular