### PR TITLE
add discover endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmdb-ts",
-  "version": "0.0.10",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tmdb-ts",
-      "version": "0.0.10",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmdb-ts",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "TMDB v3 library wrapper",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/endpoints/discover.ts
+++ b/src/endpoints/discover.ts
@@ -1,0 +1,77 @@
+import { MovieDiscoverResult, SortOption, TvShowDiscoverResult } from '../types';
+import { BaseEndpoint } from './base';
+import querystring, { ParsedUrlQueryInput } from 'querystring';
+
+const BASE_DISCOVER = '/discover';
+
+interface DiscoverQueryOptions extends ParsedUrlQueryInput{
+  language?: string;
+  sort_by?: SortOption;
+  page?: number;
+  'vote_average.gte'?: number;
+  'vote_count.gte'?: number;
+  'vote_count.lte'?: number;
+  'vote_average.lte'?: number;
+  with_watch_providers?: string;
+  watch_region?: string;
+  without_companies?: string;
+  with_watch_monetization_types?: 'flatrate' | 'free' | 'ads' | 'rent' | 'buy';
+  'with_runtime.gte'?: number;
+  'with_runtime.lte'?: number;
+  with_genres?: string;
+  without_genres?: string;
+  with_original_language?: string;
+  without_keywords?: string;
+  with_keywords?: string;
+  with_companies?: string;
+}
+
+interface MovieQueryOptions extends DiscoverQueryOptions{ 
+  region?: string;  
+  certification_country?: string;
+  certification?: string;
+  'certification.lte'?: string;
+  'certification.gte'?: string;
+  include_adult?: boolean;
+  include_video?: boolean;
+  primary_release_year?: number;
+  'primary_release_date.gte'?: string;
+  'primary_release_date.lte'?: string;
+  'release_date.gte'?: string;
+  'release_date.lte'?: string;
+  with_release_type?: string;
+  year?: number;
+  with_cast?: string;
+  with_crew?: string;
+  with_people?: string;
+}
+
+interface TvShowQueryOptions extends DiscoverQueryOptions{
+  'air_date.gte'?: string;
+  'air_date.lte'?: string;
+  'first_air_date.gte'?: string;
+  'first_air_date.lte'?: string;
+  first_air_date_year?: number;
+  timezone?: string;
+  with_networks?: string;
+  include_null_first_air_dates?: boolean;
+  screened_theatrically?: boolean;
+  with_status?: string;
+  with_type?: string;
+}
+
+export class DiscoverEndpoint extends BaseEndpoint {
+  constructor(accessToken: string) {
+    super(accessToken);
+  }
+
+  async movie(options?: MovieQueryOptions): Promise<MovieDiscoverResult> {
+    const params = querystring.encode(options);
+    return await this.api.get<MovieDiscoverResult>(`${BASE_DISCOVER}/movie?${params}`);
+  }
+
+  async tvShow(options?: TvShowQueryOptions): Promise<TvShowDiscoverResult> {
+    const params = querystring.encode(options);
+    return await this.api.get<TvShowDiscoverResult>(`${BASE_DISCOVER}/tv?${params}`);
+  }
+}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -9,3 +9,4 @@ export * from './genre';
 export * from './movies';
 export * from './configuration';
 export * from './tv-shows';
+export * from './discover';

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -8,6 +8,7 @@ import {
   SearchEndpoint,
   TvShowsEndpoint,
   ConfigurationEndpoint,
+  DiscoverEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -51,5 +52,9 @@ export default class TMDB {
 
   get tvShows(): TvShowsEndpoint{
     return new TvShowsEndpoint(this.accessToken);
+  }
+
+  get discover(): DiscoverEndpoint{
+    return new DiscoverEndpoint(this.accessToken);
   }
 }

--- a/src/types/discover.ts
+++ b/src/types/discover.ts
@@ -1,0 +1,31 @@
+import { Movie, TV } from ".";
+
+export type SortOption =
+	| 'popularity.asc'
+	| 'popularity.desc'
+	| 'release_date.asc'
+	| 'release_date.desc'
+	| 'revenue.asc'
+	| 'revenue.desc'
+	| 'primary_release_date.asc'
+	| 'primary_release_date.desc'
+	| 'original_title.asc'
+	| 'original_title.desc'
+	| 'vote_average.asc'
+	| 'vote_average.desc'
+	| 'vote_count.asc'
+	| 'vote_count.desc';
+
+export interface MovieDiscoverResult{
+	page: number;
+	results: Movie[];
+	total_results: number;
+	total_pages: number;
+}
+
+export interface TvShowDiscoverResult{
+	page: number;
+	results: TV[];
+	total_results: number;
+	total_pages: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './movies';
 export * from './search';
 export * from './tv-shows';
 export * from './watch-providers';
+export * from './discover';
 
 export interface AuthorDetails {
   name: string;


### PR DESCRIPTION
# Discover endpoint!
I added support for the [discover endpoints](https://developers.themoviedb.org/3/discover/movie-discover). All HTTP Get requests for the discover TMDB endpoint are supported.

## Additions
- New types for discover

- Discover endpoint added to the TMDB class

- All GET endpoints with /discover: movie, tv-show