### PR TITLE
add review, trending, find endpoints

### DIFF
--- a/src/endpoints/find.ts
+++ b/src/endpoints/find.ts
@@ -1,0 +1,14 @@
+import { BaseEndpoint } from './base';
+import querystring from 'querystring';
+import { ExternalIdOptions, FindResult } from '../types';
+
+export class FindEndpoint extends BaseEndpoint {
+  constructor(accessToken: string) {
+    super(accessToken);
+  }
+
+  async byId(externalId: string, options: ExternalIdOptions): Promise<FindResult> {
+    const params = querystring.encode(options);
+    return await this.api.get<FindResult>(`/find/${externalId}?${params}`);
+  }
+}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -12,4 +12,5 @@ export * from './tv-shows';
 export * from './discover';
 export * from './people';
 export * from './review';
+export * from './trending';
 

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -13,4 +13,5 @@ export * from './discover';
 export * from './people';
 export * from './review';
 export * from './trending';
+export * from './find';
 

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -11,4 +11,5 @@ export * from './configuration';
 export * from './tv-shows';
 export * from './discover';
 export * from './people';
+export * from './review';
 

--- a/src/endpoints/review.ts
+++ b/src/endpoints/review.ts
@@ -1,0 +1,12 @@
+import { ReviewDetails } from '../types';
+import { BaseEndpoint } from './base';
+
+export class ReviewEndpoint extends BaseEndpoint {
+  constructor(accessToken: string) {
+    super(accessToken);
+  }
+
+  async details(id: string): Promise<ReviewDetails> {
+    return await this.api.get<ReviewDetails>(`/review/${id}`);
+  }
+}

--- a/src/endpoints/trending.ts
+++ b/src/endpoints/trending.ts
@@ -1,0 +1,14 @@
+import { MediaType, TimeWindow, TrendingResults,  } from '../types';
+import { BaseEndpoint } from './base';
+
+export class TrendingEndpoint extends BaseEndpoint {
+  constructor(accessToken: string) {
+    super(accessToken);
+  }
+
+  async trending<T extends MediaType>(mediaType : T, timeWindow: TimeWindow): Promise<TrendingResults<T>> {
+    return await this.api.get<TrendingResults<T>>(`/trending/${mediaType}/${timeWindow}`);
+  }
+}
+
+

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -10,6 +10,7 @@ import {
   ConfigurationEndpoint,
   DiscoverEndpoint,
   PeopleEndpoint,
+  ReviewEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -61,5 +62,9 @@ export default class TMDB {
   
   get people(): PeopleEndpoint{
     return new PeopleEndpoint(this.accessToken);
+  }
+
+  get review(): ReviewEndpoint{
+    return new ReviewEndpoint(this.accessToken);
   }
 }

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -11,6 +11,7 @@ import {
   DiscoverEndpoint,
   PeopleEndpoint,
   ReviewEndpoint,
+  TrendingEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -66,5 +67,9 @@ export default class TMDB {
 
   get review(): ReviewEndpoint{
     return new ReviewEndpoint(this.accessToken);
+  }
+
+  get trending(): TrendingEndpoint{
+    return new TrendingEndpoint(this.accessToken);
   }
 }

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -12,6 +12,7 @@ import {
   PeopleEndpoint,
   ReviewEndpoint,
   TrendingEndpoint,
+  FindEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -71,5 +72,9 @@ export default class TMDB {
 
   get trending(): TrendingEndpoint{
     return new TrendingEndpoint(this.accessToken);
+  }
+
+  get find() : FindEndpoint{
+    return new FindEndpoint(this.accessToken);
   }
 }

--- a/src/types/find.ts
+++ b/src/types/find.ts
@@ -1,0 +1,29 @@
+import { ParsedUrlQueryInput } from 'querystring';
+import { Episode, Media, MediaType, Movie, Person, Season, TV } from '.';
+
+export type ExternalSource =
+	| 'imdb_id'
+	| 'freebase_mid'
+	| 'freebase_id'
+	| 'tvdb_id'
+	| 'tvrage_id'
+	| 'facebook_id'
+	| 'twitter_id'
+	| 'instagram_id';
+
+export interface ExternalIdOptions extends ParsedUrlQueryInput {
+	external_source: ExternalSource;
+	language?: string;
+}
+
+type MediaTagged<T> = T & {
+	media_type: MediaType;
+};
+
+export interface FindResult {
+	movie_results: MediaTagged<Movie>[];
+	person_results: MediaTagged<Person>[];
+	tv_results: MediaTagged<TV>[];
+	tv_episode_results: MediaTagged<Episode>[];
+	tv_season_results: MediaTagged<Season & { show_id: string }>[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ export * from './tv-shows';
 export * from './watch-providers';
 export * from './people';
 export * from './discover';
+export * from './review';
 
 export interface AuthorDetails {
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export * from './watch-providers';
 export * from './people';
 export * from './discover';
 export * from './review';
+export * from './trending';
 
 export interface AuthorDetails {
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export * from './people';
 export * from './discover';
 export * from './review';
 export * from './trending';
+export * from './find';
 
 export interface AuthorDetails {
   name: string;

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,0 +1,8 @@
+import { Review } from './';
+
+export interface ReviewDetails extends Review{
+  iso_639_1: string;
+  media_id: number;
+  media_title: number;
+  media_type: number;
+}

--- a/src/types/trending.ts
+++ b/src/types/trending.ts
@@ -1,0 +1,19 @@
+import { Movie, Person, TV } from '.';
+export type MediaType = 'all' | 'movie' | 'tv' | 'person';
+
+export type TimeWindow = 'day' | 'week';
+
+type TrendingResult<T extends MediaType> = T extends 'tv'
+? TV
+: T extends 'movie'
+? Movie
+: T extends 'person'
+? Person
+: TV | Movie | Person;
+
+export interface TrendingResults<T extends MediaType> {
+  page: number;
+  results: (TrendingResult<T> & {media_type: MediaType})[];
+  total_pages: number;
+  total_results: number;
+}

--- a/src/types/tv-shows.ts
+++ b/src/types/tv-shows.ts
@@ -100,6 +100,8 @@ export interface Episode {
   still_path: string
   vote_average: number
   vote_count: number
+  show_id: number;
+  runtime: number;
 }
 
 export interface SeasonDetails {


### PR DESCRIPTION
# Three new endpoints supported
since all of them seemed pretty small I combined them in this pull request.
I added support for the 
 - [review endpoints](https://developers.themoviedb.org/3/reviews/get-review-details)
 - [trending endpoints](https://developers.themoviedb.org/3/trending/get-trending)
 - [find endpoints](https://developers.themoviedb.org/3/find/find-by-id)

All HTTP Get requests for all the 3 TMDB endpoints are supported.

## Additions
- New types for review, trending and find enpoints
- Updated Episode type
- Endpoints added to the TMDB class
- All GET endpoints with /review, /find, /trending