### PR TITLE
Keywords collections endpoint

### DIFF
--- a/src/endpoints/collections.ts
+++ b/src/endpoints/collections.ts
@@ -1,4 +1,4 @@
-import { DetailedCollection, LanguageOption, PageOption } from '../types';
+import { DetailedCollection, ImageCollection, LanguageOption, PageOption, Translations } from '../types';
 import {  BaseEndpoint } from './base';
 import querystring from 'querystring';
 
@@ -12,6 +12,16 @@ export class CollectionsEndpoint extends BaseEndpoint {
   async details(id: number, options? : LanguageOption): Promise<DetailedCollection> {
     const params = querystring.encode(options);
     return await this.api.get<DetailedCollection>(`${BASE_COLLECTION}/${id}?${params}`);
+  }
+
+  async images(id: number, options? : LanguageOption): Promise<ImageCollection> {
+    const params = querystring.encode(options);
+    return await this.api.get<ImageCollection>(`${BASE_COLLECTION}/${id}/images?${params}`);
+  }
+
+  async translations(id: number, options? : LanguageOption): Promise<Translations> {
+    const params = querystring.encode(options);
+    return await this.api.get<Translations>(`${BASE_COLLECTION}/${id}/translations?${params}`);
   }
 
 }

--- a/src/endpoints/collections.ts
+++ b/src/endpoints/collections.ts
@@ -1,0 +1,17 @@
+import { DetailedCollection, LanguageOption, PageOption } from '../types';
+import {  BaseEndpoint } from './base';
+import querystring from 'querystring';
+
+const BASE_COLLECTION = '/collection';
+
+export class CollectionsEndpoint extends BaseEndpoint {
+  constructor(protected readonly accessToken: string) {
+    super(accessToken);
+  }
+
+  async details(id: number, options? : LanguageOption): Promise<DetailedCollection> {
+    const params = querystring.encode(options);
+    return await this.api.get<DetailedCollection>(`${BASE_COLLECTION}/${id}?${params}`);
+  }
+
+}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -14,4 +14,5 @@ export * from './people';
 export * from './review';
 export * from './trending';
 export * from './find';
+export * from './keywords';
 

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -15,4 +15,5 @@ export * from './review';
 export * from './trending';
 export * from './find';
 export * from './keywords';
+export * from './collections';
 

--- a/src/endpoints/keywords.ts
+++ b/src/endpoints/keywords.ts
@@ -1,0 +1,20 @@
+import { BaseEndpoint } from './base';
+import querystring from 'querystring';
+import { BelongingMovies, Keyword, KeywordsOptions } from '../types';
+
+const BASE_Keyword = '/keyword';
+
+export class KeywordsEndpoint extends BaseEndpoint {
+  constructor(accessToken: string) {
+    super(accessToken);
+  }
+
+  async details(keywordId : number): Promise<Keyword> {
+    return await this.api.get<Keyword>(`${BASE_Keyword}/${keywordId}`);
+  }
+
+  async belongingMovies(keywordId : number, options?: KeywordsOptions): Promise<BelongingMovies> {
+    const params = querystring.encode(options);
+    return await this.api.get<BelongingMovies>(`${BASE_Keyword}/${keywordId}/movies?${params}`);
+  }
+}

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -14,6 +14,7 @@ import {
   TrendingEndpoint,
   FindEndpoint,
   KeywordsEndpoint,
+  CollectionsEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -81,5 +82,9 @@ export default class TMDB {
 
   get keywords() : KeywordsEndpoint{
     return new KeywordsEndpoint(this.accessToken);
+  }
+
+  get collections() : CollectionsEndpoint{
+    return new CollectionsEndpoint(this.accessToken);
   }
 }

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -13,6 +13,7 @@ import {
   ReviewEndpoint,
   TrendingEndpoint,
   FindEndpoint,
+  KeywordsEndpoint,
 } from './endpoints';
 
 export default class TMDB {
@@ -76,5 +77,9 @@ export default class TMDB {
 
   get find() : FindEndpoint{
     return new FindEndpoint(this.accessToken);
+  }
+
+  get keywords() : KeywordsEndpoint{
+    return new KeywordsEndpoint(this.accessToken);
   }
 }

--- a/src/types/collections.ts
+++ b/src/types/collections.ts
@@ -1,0 +1,16 @@
+import { Movie } from ".";
+
+export interface Collection {
+	id: number;
+	backdrop_path: string;
+	name: string;
+	poster_path: string;
+	adult: boolean;
+	original_language: string;
+	original_name: string;
+	overview: string;
+}
+
+export interface DetailedCollection extends Collection {
+  parts: Movie[]
+}

--- a/src/types/credits.ts
+++ b/src/types/credits.ts
@@ -125,13 +125,3 @@ export interface Videos {
   id: number;
   results: Video[];
 }
-
-export interface Keywords {
-  id: number;
-  keywords: Array<{
-    id: number;
-    name: string;
-  }>
-
-}
-

--- a/src/types/credits.ts
+++ b/src/types/credits.ts
@@ -1,4 +1,4 @@
-import { Person } from './';
+import { Image, Person } from './';
 
 export interface CreditSeason {
   air_date?: string;
@@ -82,31 +82,10 @@ export interface Credits {
   crew: Crew[];
 }
 
-
-export interface Backdrop {
-  aspect_ratio: number;
-  file_path: string;
-  height: number;
-  iso_639_1?: any;
-  vote_average: number;
-  vote_count: number;
-  width: number;
-}
-
-export interface Poster {
-  aspect_ratio: number;
-  file_path: string;
-  height: number;
-  iso_639_1: string;
-  vote_average: number;
-  vote_count: number;
-  width: number;
-}
-
-export interface CreditImages {
+export interface ImageCollection {
   id: number;
-  backdrops: Backdrop[];
-  posters: Poster[];
+  backdrops: Image[];
+  posters: Image[];
 }
 
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export * from './discover';
 export * from './review';
 export * from './trending';
 export * from './find';
+export * from './keywords';
 
 export interface AuthorDetails {
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,8 +53,6 @@ export interface Person {
 
 export interface Movie {
   id: number;
-  logo_path: string;
-  name: string;
   poster_path: string;
   adult: boolean;
   overview: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './options';
 export * from './certification';
 export *  from './credits';
 export * from './configuration';
@@ -12,6 +13,7 @@ export * from './review';
 export * from './trending';
 export * from './find';
 export * from './keywords';
+export * from './collections';
 
 export interface AuthorDetails {
   name: string;
@@ -47,13 +49,6 @@ export interface Person {
   known_for_department: string;
   gender: number;
   popularity: number;
-}
-
-export interface Collection {
-  id:number;
-  backdrop_path: string;
-  name: string;
-  poster_path: string;
 }
 
 export interface Movie {

--- a/src/types/keywords.ts
+++ b/src/types/keywords.ts
@@ -1,0 +1,19 @@
+import { ParsedUrlQueryInput } from 'querystring';
+import { Movie } from '.';
+
+export interface KeywordsOptions extends ParsedUrlQueryInput {
+	include_adult?: boolean;
+	language?: string;
+}
+
+export interface BelongingMovies{
+  page: number;
+	results: Movie[];
+	total_results: number;
+	total_pages: number;
+}
+
+export interface Keyword{
+  id: number;
+  name: string;
+}

--- a/src/types/keywords.ts
+++ b/src/types/keywords.ts
@@ -17,3 +17,8 @@ export interface Keyword{
   id: number;
   name: string;
 }
+
+export interface Keywords {
+  id: number;
+  keywords: Keyword[];
+}

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,0 +1,9 @@
+import { ParsedUrlQueryInput } from 'querystring';
+
+export interface LanguageOption extends ParsedUrlQueryInput {
+	language?: string;
+}
+
+export interface PageOption extends ParsedUrlQueryInput {
+	page?: number;
+}


### PR DESCRIPTION
# Two new endpoints supported
I combined them in this pull request.
I added support for the 
 - [keywords endpoints](https://developers.themoviedb.org/3/keywords/get-keyword-details)
 - [collections endpoints](https://developers.themoviedb.org/3/collections/get-collection-details)

All HTTP Get requests for all the 2 TMDB endpoints are supported.

## Additions
- New types for keywords and collections endpoint
- Updated Keywords interface, ImageCollection interface 
- Added new Option Interfaces to use when creating option parameters for the endpoint
 For Example, adding language and page options by conditionally combining the interfaces:
 `async details(id: number, options? : LanguageOption & PageOption)`
- Endpoints added to the TMDB class
- All GET endpoints with /keywords, /collections