### PR TITLE
Fix images array is empty because languages equal to undefined on URLSearchParams

### DIFF
--- a/src/utils/parseOptions.ts
+++ b/src/utils/parseOptions.ts
@@ -1,4 +1,9 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 export function parseOptions(options?: Record<string, any>): string {
-  return options ? new URLSearchParams(Object.entries(options)).toString() : '';
+  return options
+    ? new URLSearchParams(
+        Object.entries(options)
+          .filter(([k, v]) => v) // remove undefined
+      ).toString()
+    : '';
 }


### PR DESCRIPTION
code
`await tmdb.movies.images(id)`

requested url before:
`https://api.themoviedb.org/3/movie/tt0063350/images?include_image_language=undefined&language=undefined`

requested url after:
`https://api.themoviedb.org/3/movie/tt0063350/images?`