### PR TITLE
fix: movie imdb_id is nullable

### DIFF
--- a/src/types/movies.ts
+++ b/src/types/movies.ts
@@ -22,7 +22,7 @@ export interface MovieDetails {
   genres: Genre[];
   homepage: string;
   id: number;
-  imdb_id: string;
+  imdb_id: string | null;
   original_language: string;
   original_title: string;
   overview: string;
@@ -104,7 +104,7 @@ export interface LatestMovie {
   genres: Genre[];
   homepage: string;
   id: number;
-  imdb_id: string;
+  imdb_id: string | null;
   original_language: string;
   original_title: string;
   overview: string;


### PR DESCRIPTION
This is also a problem in tmdb's docs/schema but I don't know how to submit issues for them to resolve. It is listed as a string but it will be null when there is no IMDB ID for the entry.

Example: `GET` `https://api.themoviedb.org/3/movie/1443826`
<img width="163" alt="image" src="https://github.com/user-attachments/assets/a048f3be-9ca3-42ce-9d24-800be385a2d0" />
