### PR TITLE
add tagline field to TranslationData interface

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -197,6 +197,7 @@ export interface TranslationData {
   overview: string;
   homepage: string;
   tagline: string;
+  runtime: number;
 }
 
 export interface Translation {


### PR DESCRIPTION
### Purpose

Add missing fields to the `TranslationData` interface to fully align it with the original source.

### Result

* `TranslationData` now fully matches the original specification

### Reference

Original source: **https://developer.themoviedb.org/reference/movie-translations**

